### PR TITLE
Use OCaml 4.09 for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ env:
   - OPAMJOBS="2"
   - OPAMYES="true"
   - OPAMVERBOSE="true"
-  - OCAML_VERSION=4.06.0
+  - OCAML_VERSION=4.09.0
 
 before_install:
   # Obtain and install opam locally.
-  - sudo wget https://github.com/ocaml/opam/releases/download/2.0.0/opam-2.0.0-x86_64-linux -O /usr/bin/opam
+  - sudo wget https://github.com/ocaml/opam/releases/download/2.0.5/opam-2.0.5-x86_64-linux -O /usr/bin/opam
   - sudo chmod 755 /usr/bin/opam
   # Initialize the switch.
   - opam init -a --disable-sandboxing --compiler="$OCAML_VERSION"


### PR DESCRIPTION
Apparently there are no dependencies that restrict the most modern OCaml version use.